### PR TITLE
Fixing `require()` name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ When rendered by an Express 4.0 app:
 
 ```
 var express = require('express'),
-  engine = require('../'),
+  engine = require('ejs-mate'),
   app = express();
 
 // use ejs-locals for all ejs templates:


### PR DESCRIPTION
This tripped me up at first, so I thought I'd help out ;)
