### PR TITLE
Problem passing locals object to partials

### DIFF
--- a/test/fixtures/partial-locals-partial.ejs
+++ b/test/fixtures/partial-locals-partial.ejs
@@ -1,0 +1,1 @@
+<p><%= childNamespaceVariable %></p>

--- a/test/fixtures/partial-locals.ejs
+++ b/test/fixtures/partial-locals.ejs
@@ -1,0 +1,1 @@
+<h1>Partial</h1><%- partial( 'partial-locals-partial', { locals:{ childNamespaceVariable:parentNamespaceVariable } } ) %>

--- a/test/test.partials.js
+++ b/test/test.partials.js
@@ -148,6 +148,10 @@ app.get('/deep-partial-relative-to-app-views', function(req,res,next) {
   res.render('path/to/deep-partial.ejs', {hello: 'Hi'});
 })
 
+app.get('/partial-locals',function(req,res,next){
+  res.render('partial-locals.ejs',{ parentNamespaceVariable :'splendid' });
+})
+
 // override the default error handler so it doesn't log to console:
 app.use(function(err,req,res,next) {
   // console.log(err.stack);
@@ -487,6 +491,18 @@ describe('app',function(){
         .end(function(res){
           res.should.have.status(200);
           res.body.should.equal('<html><head><title>ejs-locals</title></head><body><div><section><h1>Hi</h1></section></div></body></html>');
+          done();
+        })
+    })
+  })
+
+  describe('GET /partial-locals',function(){
+    it('should render a partial passing in data via `locals` object',function(done){
+      request(app)
+        .get('/partial-locals')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<html><head><title>ejs-locals</title></head><body><h1>Partial</h1><p>splendid</p></body></html>');
           done();
         })
     })


### PR DESCRIPTION
Hi there, really handy library, thanks for sharing.

I came across a bit of an issue trying to pass data into partials. Not sure what your preferred solution is but I've added tests to show my problem.

Basically I want to do the following, but it doesn't seem to work:

```
partial('name',{ locals : { foo : 'bar' });
```

Looking at the code, the render() method seems to be copying `locals` data onto the `options` object before sending it to `ejs`, so the locals don't get picked up by `ejs` when rendering.

I haven't attempted a solution yet as I'm not sure what I might break.

Any thoughts?
